### PR TITLE
Inject

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -92,6 +92,21 @@ The server looks for tools in this order:
 4. Auto-detection based on project type
 5. Config directory: `~/.config/gamecode-mcp/tools.yaml`
 
+## Server-Side Value Injection
+
+For scenarios where you need to provide values that the LLM should not control (e.g., multi-tenant environments), use the `--inject` flag:
+
+```bash
+gamecode-mcp2 --inject tenant=customer123 --inject environment=production
+```
+
+Injected values are:
+- Set as environment variables with `GAMECODE_` prefix (e.g., `GAMECODE_TENANT`)
+- Available to all executed tools but not visible to the LLM
+- Useful for enforcing security boundaries in multi-tenant deployments
+
+**Important**: This provides a separation of concerns but is not a complete security solution. Always validate tool inputs and follow defense-in-depth principles.
+
 ## Examples
 
 See the `examples/` directory for tool configurations for various use cases:
@@ -99,6 +114,7 @@ See the `examples/` directory for tool configurations for various use cases:
 - `development/`: Language-specific development tools
 - `security/`: Security-focused configurations
 - `data/`: Data processing tools
+- `multi-tenant-example.yaml`: Using injected values for tenant isolation
 
 ## Security Considerations
 

--- a/mcp-server/examples/multi-tenant-example.yaml
+++ b/mcp-server/examples/multi-tenant-example.yaml
@@ -1,0 +1,33 @@
+tools:
+  # Example tool that would use injected tenant/environment values
+  - name: query_tenant_data
+    description: Query data for the current tenant
+    command: ./scripts/query-tenant.sh
+    args:
+      - name: query
+        description: SQL query to execute
+        required: true
+        type: string
+        cli_flag: --query
+    # The script would access GAMECODE_TENANT and GAMECODE_ENVIRONMENT
+    # environment variables that are automatically set from --inject
+
+  - name: deploy_to_environment
+    description: Deploy application to current environment
+    command: ./scripts/deploy.sh
+    args:
+      - name: version
+        description: Version to deploy
+        required: true
+        type: string
+        cli_flag: --version
+    # The script would access GAMECODE_ENVIRONMENT to know where to deploy
+
+# Usage:
+# gamecode-mcp2 --inject tenant=customer123 --inject environment=staging --tools-file multi-tenant-example.yaml
+#
+# The tools will have access to:
+# - GAMECODE_TENANT=customer123
+# - GAMECODE_ENVIRONMENT=staging
+#
+# This ensures the LLM cannot override these security-critical values

--- a/mcp-server/src/handlers.rs
+++ b/mcp-server/src/handlers.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use serde_json::Value;
+use std::collections::HashMap;
 use tracing::{debug, error, info};
 
 use crate::protocol::*;
@@ -10,11 +11,12 @@ use crate::tools::ToolManager;
 
 pub struct RequestHandler {
     tool_manager: ToolManager,
+    injected_values: HashMap<String, String>,
 }
 
 impl RequestHandler {
-    pub fn new(tool_manager: ToolManager) -> Self {
-        Self { tool_manager }
+    pub fn new(tool_manager: ToolManager, injected_values: HashMap<String, String>) -> Self {
+        Self { tool_manager, injected_values }
     }
 
     // Request dispatch - only these three methods exist, nothing else
@@ -126,7 +128,7 @@ impl RequestHandler {
         // Execute only configured tools with validated parameters
         match self
             .tool_manager
-            .execute_tool(&params.name, params.arguments)
+            .execute_tool(&params.name, params.arguments, &self.injected_values)
             .await
         {
             Ok(result) => {

--- a/mcp-server/tests/protocol_tests.rs
+++ b/mcp-server/tests/protocol_tests.rs
@@ -2,13 +2,14 @@ use gamecode_mcp2::handlers::RequestHandler;
 use gamecode_mcp2::protocol::*;
 use gamecode_mcp2::tools::ToolManager;
 use serde_json::json;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 async fn setup_handler() -> RequestHandler {
     let mut tool_manager = ToolManager::new();
     let path = PathBuf::from("tests/fixtures/test_tools.yaml");
     tool_manager.load_from_file(&path).await.unwrap();
-    RequestHandler::new(tool_manager)
+    RequestHandler::new(tool_manager, HashMap::new())
 }
 
 #[tokio::test]

--- a/mcp-server/tests/security_tests.rs
+++ b/mcp-server/tests/security_tests.rs
@@ -1,5 +1,6 @@
 use gamecode_mcp2::tools::ToolManager;
 use serde_json::json;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -25,7 +26,7 @@ async fn test_path_traversal_prevention() {
         });
 
         // Current implementation doesn't prevent this - documenting the risk
-        let result = tool_manager.execute_tool("file_writer", args).await;
+        let result = tool_manager.execute_tool("file_writer", args, &HashMap::new()).await;
 
         // This test documents that path traversal IS possible
         // In a secure implementation, these should all fail
@@ -55,7 +56,7 @@ async fn test_command_argument_injection() {
             "message": attempt
         });
 
-        let result = tool_manager.execute_tool("echo_test", args).await;
+        let result = tool_manager.execute_tool("echo_test", args, &HashMap::new()).await;
         assert!(result.is_ok(), "Command should execute");
 
         let output = result.unwrap();
@@ -175,7 +176,7 @@ async fn test_symlink_traversal() {
             "content": "new content"
         });
 
-        let result = tool_manager.execute_tool("file_writer", args).await;
+        let result = tool_manager.execute_tool("file_writer", args, &HashMap::new()).await;
 
         // Current implementation follows symlinks - documenting the risk
         if result.is_ok() {

--- a/mcp-server/tests/tool_execution_tests.rs
+++ b/mcp-server/tests/tool_execution_tests.rs
@@ -1,5 +1,6 @@
 use gamecode_mcp2::tools::ToolManager;
 use serde_json::json;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -13,7 +14,7 @@ async fn test_execute_echo_command() {
         "message": "Hello, World!"
     });
 
-    let result = tool_manager.execute_tool("echo_test", args).await;
+    let result = tool_manager.execute_tool("echo_test", args, &HashMap::new()).await;
     assert!(result.is_ok(), "Echo command failed: {:?}", result);
 
     let output = result.unwrap();
@@ -31,7 +32,7 @@ async fn test_execute_internal_math() {
         "b": 3.0
     });
 
-    let result = tool_manager.execute_tool("math_add", args).await;
+    let result = tool_manager.execute_tool("math_add", args, &HashMap::new()).await;
     assert!(result.is_ok(), "Math addition failed: {:?}", result);
 
     let output = result.unwrap();
@@ -54,7 +55,7 @@ async fn test_execute_file_operations() {
         "content": "Test content"
     });
 
-    let write_result = tool_manager.execute_tool("file_writer", write_args).await;
+    let write_result = tool_manager.execute_tool("file_writer", write_args, &HashMap::new()).await;
     assert!(
         write_result.is_ok(),
         "File write failed: {:?}",
@@ -70,7 +71,7 @@ async fn test_execute_file_operations() {
         "path": temp_dir.path().to_str().unwrap()
     });
 
-    let list_result = tool_manager.execute_tool("list_dir", list_args).await;
+    let list_result = tool_manager.execute_tool("list_dir", list_args, &HashMap::new()).await;
     assert!(
         list_result.is_ok(),
         "Directory listing failed: {:?}",
@@ -90,7 +91,7 @@ async fn test_execute_nonexistent_tool() {
     tool_manager.load_from_file(&path).await.unwrap();
 
     let args = json!({});
-    let result = tool_manager.execute_tool("does_not_exist", args).await;
+    let result = tool_manager.execute_tool("does_not_exist", args, &HashMap::new()).await;
 
     assert!(result.is_err(), "Should fail for nonexistent tool");
     assert!(result.unwrap_err().to_string().contains("not found"));
@@ -107,7 +108,7 @@ async fn test_execute_missing_required_args() {
 
     // The current implementation might not validate required args
     // This test documents the current behavior
-    let result = tool_manager.execute_tool("echo_test", args).await;
+    let result = tool_manager.execute_tool("echo_test", args, &HashMap::new()).await;
 
     // If validation is added later, this test should be updated
     // For now, it likely succeeds but with empty output
@@ -129,7 +130,7 @@ async fn test_command_injection_prevention() {
         "message": "test; rm -rf /tmp/test"
     });
 
-    let result = tool_manager.execute_tool("echo_test", args).await;
+    let result = tool_manager.execute_tool("echo_test", args, &HashMap::new()).await;
     assert!(result.is_ok(), "Command should execute safely");
 
     let output = result.unwrap();

--- a/mcp-server/tests/validation_tests.rs
+++ b/mcp-server/tests/validation_tests.rs
@@ -1,5 +1,6 @@
 use gamecode_mcp2::tools::ToolManager;
 use serde_json::json;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[tokio::test]
@@ -13,7 +14,7 @@ async fn test_path_validation_rejection() {
         "file": "../../../etc/passwd"
     });
 
-    let result = tool_manager.execute_tool("safe_file_reader", args).await;
+    let result = tool_manager.execute_tool("safe_file_reader", args, &HashMap::new()).await;
     assert!(result.is_err());
     assert!(result
         .unwrap_err()
@@ -32,7 +33,7 @@ async fn test_absolute_path_rejection() {
         "file": "/etc/passwd"
     });
 
-    let result = tool_manager.execute_tool("safe_file_reader", args).await;
+    let result = tool_manager.execute_tool("safe_file_reader", args, &HashMap::new()).await;
     assert!(result.is_err());
     assert!(result
         .unwrap_err()
@@ -51,7 +52,7 @@ async fn test_validation_allows_safe_paths() {
         "file": "README.md"
     });
 
-    let result = tool_manager.execute_tool("safe_file_reader", args).await;
+    let result = tool_manager.execute_tool("safe_file_reader", args, &HashMap::new()).await;
     // This might fail if README.md doesn't exist, but shouldn't fail validation
     if result.is_err() {
         let err = result.unwrap_err().to_string();
@@ -71,7 +72,7 @@ async fn test_unrestricted_tool_works() {
         "message": "../../../etc/passwd; cat /etc/shadow"
     });
 
-    let result = tool_manager.execute_tool("unrestricted_echo", args).await;
+    let result = tool_manager.execute_tool("unrestricted_echo", args, &HashMap::new()).await;
     assert!(result.is_ok());
 
     // But the content should be literal (no execution)
@@ -93,7 +94,7 @@ async fn test_null_byte_rejection() {
         "file": "file.txt\0.bypass"
     });
 
-    let result = tool_manager.execute_tool("safe_file_reader", args).await;
+    let result = tool_manager.execute_tool("safe_file_reader", args, &HashMap::new()).await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("null byte"));
 }


### PR DESCRIPTION
## Server-Side Value Injection

The `--inject` flag allows you to pass server-side values that are invisible to
the LLM but available to your tools. This is essential for multi-tenant
scenarios where the LLM must not control security-critical parameters.

### How it works

```bash
gamecode-mcp2 --inject tenant=customer123 --inject environment=production
```

When tools execute, they receive these as environment variables:
- `tenant=customer123` → `GAMECODE_TENANT=customer123`
- `environment=production` → `GAMECODE_ENVIRONMENT=production`

